### PR TITLE
Enhance agent status dashboard with richer information

### DIFF
--- a/internal/gastown/types.go
+++ b/internal/gastown/types.go
@@ -56,13 +56,16 @@ type Rig struct {
 
 // Agent represents a Gas Town agent (polecat, witness, etc.).
 type Agent struct {
-	Role       Role        `json:"role"`
-	Name       string      `json:"name"`
-	Rig        string      `json:"rig,omitempty"`
-	Status     AgentStatus `json:"status"`
-	Session    string      `json:"session,omitempty"`
-	Molecule   string      `json:"molecule,omitempty"`
-	LastActive time.Time   `json:"last_active,omitempty"`
+	Role         Role        `json:"role"`
+	Name         string      `json:"name"`
+	Rig          string      `json:"rig,omitempty"`
+	Status       AgentStatus `json:"status"`
+	Session      string      `json:"session,omitempty"`
+	Molecule     string      `json:"molecule,omitempty"`
+	HookAttached bool        `json:"hook_attached,omitempty"`
+	LastActive   time.Time   `json:"last_active,omitempty"`
+	Compaction   int         `json:"compaction,omitempty"`
+	WorkDir      string      `json:"work_dir,omitempty"`
 }
 
 // Address returns the mail-style address for this agent.

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -433,6 +433,37 @@
   font-family: monospace;
 }
 
+.agent-card.agent-stuck {
+  border-color: #ef4444;
+  background: linear-gradient(135deg, #0f172a 0%, #1a0a0a 100%);
+}
+
+.hook-indicator {
+  margin-left: 0.375rem;
+  font-size: 0.875rem;
+}
+
+.agent-details {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.375rem;
+  font-size: 0.75rem;
+}
+
+.agent-molecule {
+  color: #a78bfa;
+  font-family: monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 150px;
+}
+
+.agent-activity {
+  color: #64748b;
+}
+
 /* Rig Card */
 .rigs-grid {
   display: grid;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -154,6 +154,21 @@ function IssueDetail({
 
 // Gas Town Components
 
+function formatTimeAgo(dateStr?: string): string {
+  if (!dateStr) return '';
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}d ago`;
+}
+
 function AgentCard({ agent }: { agent: Agent }) {
   const roleIcons: Record<string, string> = {
     mayor: '👑',
@@ -165,15 +180,32 @@ function AgentCard({ agent }: { agent: Agent }) {
   };
 
   return (
-    <div className="agent-card">
+    <div className={`agent-card ${agent.status === 'stuck' ? 'agent-stuck' : ''}`}>
       <div className="agent-icon">{roleIcons[agent.role] || '🤖'}</div>
       <div className="agent-info">
-        <div className="agent-name">{agent.name}</div>
+        <div className="agent-name">
+          {agent.name}
+          {agent.hook_attached && <span className="hook-indicator" title="Work attached">🪝</span>}
+        </div>
         <div className="agent-meta">
           <StatusBadge status={agent.status} />
           <span className="agent-role">{agent.role}</span>
           {agent.rig && <span className="agent-rig">{agent.rig}</span>}
         </div>
+        {(agent.molecule || agent.last_active) && (
+          <div className="agent-details">
+            {agent.molecule && (
+              <span className="agent-molecule" title="Current molecule">
+                📋 {agent.molecule}
+              </span>
+            )}
+            {agent.last_active && (
+              <span className="agent-activity" title="Last activity">
+                {formatTimeAgo(agent.last_active)}
+              </span>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -140,6 +140,10 @@ export interface Agent {
   status: AgentStatus;
   session?: string;
   molecule?: string;
+  hook_attached?: boolean;
+  last_active?: string;
+  compaction?: number;
+  work_dir?: string;
 }
 
 export interface Rig {


### PR DESCRIPTION
## Summary

- Enhanced Gastown adapter to read seance, hook, and molecule files for richer agent info
- Added smart status detection (active/idle/stuck based on activity)
- Web UI now shows molecule IDs, hook indicators, and relative activity times
- Visual highlighting for stuck agents

## What's New

**Backend:**
- `enrichAgent()` method reads session/hook/molecule state from agent workspaces
- Status detection: active (session running), idle (2+ min no activity), stuck (10+ min)
- New Agent fields: hook_attached, last_active, compaction, work_dir

**Web UI:**
- Hook indicator (hook emoji) when work is attached
- Molecule ID display
- Relative time ("5m ago", "2h ago")
- Red border for stuck agents

## Test plan

- [ ] Build Go backend: `go build ./...`
- [ ] Run Go tests: `go test ./...`
- [ ] Build web UI: `cd web && npm run build`
- [ ] Start daemon and check `/api/v1/town/agents` returns enriched data
- [ ] Verify agent cards show molecule, hook indicator, activity time

🤖 Generated with [Claude Code](https://claude.com/claude-code)