### PR TITLE
feat(api): daemon hardening — Origin allowlist + session token + loopback bind + THREAT_MODEL.md

### DIFF
--- a/000-docs/005-PP-POLICY-memories-classification-2026-05-24.md
+++ b/000-docs/005-PP-POLICY-memories-classification-2026-05-24.md
@@ -1,0 +1,169 @@
+# 005 · PP · POLICY · Memories Classification — 2026-05-24
+
+| Field | Value |
+|---|---|
+| **Date** | 2026-05-24 |
+| **Status** | In force from the day the memories panel ships (`gastown-3uf`) |
+| **Authoring bead** | `gastown-hu4` |
+| **Source decision** | `000-docs/004-AT-DECR-gastown-viewer-option-b-council-2026-05-23.md` Q2 + GC binding constraint |
+| **Reviewers** | Jeremy Longshore (data owner); Acting Head of Board on Council 2026-05-23 |
+
+## 1. Purpose
+
+Specify how the `bd memories` content layer is classified, redacted, and
+rendered in the Gastown Viewer Intent dashboard. The council's binding
+constraint on memories (read-only-forever architectural invariant) takes
+the **write** surface off the table; this policy governs the **read**
+surface — what the dashboard is allowed to display, what it must redact,
+and what affordances must be present on every memories-touching element.
+
+This policy is normative for any code path that surfaces memory content in
+the browser. It does NOT govern the `bd remember` CLI surface — that is
+the canonical writer and its operational guidance lives in the global
+`~/.claude/CLAUDE.md` § "Auto memory" section.
+
+## 2. Scope
+
+Applies to:
+
+- Every HTTP handler under `/api/v1/memories/*` (read-only).
+- Every React component in `web/src/` that renders memory content.
+- Any future SSE event payload that streams memory deltas.
+
+Does NOT apply to:
+
+- The `bd remember` / `bd memories` / `bd recall` CLI commands. Those are
+  governed by bd's own posture and the global Claude memory file.
+- Memory content that never reaches the viewer (e.g., memories stored by
+  other tools in the same `.beads/` Dolt schema).
+
+## 3. Classification
+
+Two classes of memory content trigger redaction in the viewer:
+
+### Class A — Partner names
+
+The viewer treats the following case-insensitive substring matches as
+partner-name signal:
+
+- `kobiton`
+- `nixtla`
+- `mudit` (covers both "Mudit Gupta" and "Mudit Goyal" variants)
+- `polygon`
+- `lit` (matched as a whole-word token, NOT a substring — otherwise it
+  would false-positive on "literature", "literally", "splitting", etc.)
+- `elm` (whole-word token; false-positive risk on "elmer", "helm",
+  "realm" otherwise)
+
+The denylist is conservatively narrow on purpose. Adding a new partner is
+a one-line change to `internal/api/memoryredact.go` (lands with
+`gastown-3uf`) and a corresponding update to this section of this policy.
+Removing a partner from the denylist is a separate decision because it
+means data that was previously redacted becomes visible — pre-existing
+screen-recording exposure does not unrender retroactively.
+
+### Class B — Secret-pattern strings
+
+The viewer redacts any token-like substring matching the following
+patterns (case-sensitive — these prefixes are case-sensitive in their
+canonical issuers' formats):
+
+| Pattern        | Issuer / kind                                  |
+|----------------|------------------------------------------------|
+| `sk-...`       | OpenAI API keys (also Anthropic legacy format) |
+| `sk-ant-...`   | Anthropic API keys                             |
+| `ghp_...`      | GitHub personal access tokens (PAT)            |
+| `gho_...`      | GitHub OAuth tokens                            |
+| `ghs_...`      | GitHub Apps server-to-server tokens            |
+| `ghr_...`      | GitHub refresh tokens                          |
+| `AKIA...`      | AWS access key IDs (long-term)                 |
+| `ASIA...`      | AWS access key IDs (temporary / STS)           |
+| `glpat-...`    | GitLab personal access tokens                  |
+| `tlk_...`      | Twilio API keys                                |
+
+The matching rule is: any continuous run of non-whitespace characters of
+length ≥ 16 that begins with one of these prefixes. Length floor exists
+to avoid false-positives on prose ("we use sk-as-an-acronym").
+
+Patterns may be added without a separate review. Removing a pattern from
+the denylist requires the same paper-trail discipline as Class A removal.
+
+## 4. Rendering behavior
+
+The viewer applies the following behavior to all memory content rendered
+in the browser:
+
+1. **Default state — redacted.** When the memories panel first renders,
+   every Class-A and Class-B match in every visible memory is replaced
+   with a `[REDACTED partner-name]` or `[REDACTED secret]` overlay
+   element. The original bytes are NOT included in the rendered HTML —
+   the redaction happens server-side in the handler before the JSON ever
+   leaves the daemon process.
+
+2. **Show toggle per memory.** Each memory has a "show" button that
+   reveals the un-redacted version IF the engineer clicks. The reveal
+   re-fetches the memory from the daemon with `?reveal=true`; the daemon
+   logs the reveal event to the audit log (path TBD with the panel work
+   in `gastown-3uf`). The reveal lasts until the next page reload or
+   navigation away; it does not persist.
+
+3. **No autocomplete surface.** Every input element in the viewer — even
+   read-only search boxes on the memories panel — sets
+   `autocomplete="off"`. The architectural invariant (read-only-forever)
+   means there are no write inputs, but the search box is itself an
+   input the browser could remember.
+
+4. **No clipboard auto-copy.** The memory body is NOT auto-selected when
+   focused. Clicking a memory copies its ID to the clipboard, never the
+   content. Engineer wants the content → CLI: `bd recall <id>`.
+
+5. **Screen-share warning banner.** When the memories panel mounts, a
+   non-dismissible banner at the top reads "MEMORIES — sensitive content;
+   close before screen-sharing." Banner stays for the lifetime of the
+   panel; engineer must navigate away to remove it.
+
+## 5. False-positive handling
+
+Engineer can mark a specific memory as "false-positive — render in full"
+via a CLI: `bd memories --no-redact <id>`. This sets a flag on the memory
+that the viewer's redaction layer honors. Flag is per-memory, not
+per-pattern — turning off redaction for one memory does not silence the
+denylist globally.
+
+## 6. Logging
+
+The daemon logs:
+
+- Reveal events (memory ID, timestamp, but NOT the revealed content).
+- False-positive marks (memory ID, timestamp, who marked it — always the
+  daemon-owning user, but logged for parity).
+
+The daemon does NOT log:
+
+- Memory content. Ever.
+- The session token (see THREAT_MODEL.md).
+- Any partner-name string from a redacted memory, even when reveal is on.
+
+## 7. Review cadence
+
+This policy is reviewed:
+
+- When a new partner is added to the engagement portfolio (additive).
+- When a memory leak is suspected (root-cause analysis updates the
+  classification rules).
+- Annually as part of `gastown-cr5`'s closeout review, regardless of
+  whether incidents occurred.
+
+## 8. Open items
+
+Tracked under the `gastown-cr5` epic. None block `gastown-hu4` from
+shipping; these complete the policy-to-code wiring in subsequent bursts.
+
+- `gastown-3uf` — implement `internal/api/memoryredact.go` applying
+  this policy. Add unit tests with one fixture per Class-A name and one
+  per Class-B pattern.
+- Future bead — surface the reveal audit log in a viewer panel so the
+  engineer can see "I revealed X memories today" without grepping logs.
+- Future bead — extend the secret-pattern denylist with project-specific
+  prefixes from a config file (today the list is compiled in; the future
+  list reads `internal/api/secret-patterns.yaml`).

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -1,0 +1,185 @@
+# Threat Model — Gastown Viewer Intent
+
+**Status:** v1.0 · Authored 2026-05-24 as part of bead `gastown-hu4` per the
+`000-docs/004-AT-DECR-gastown-viewer-option-b-council-2026-05-23.md` council
+decision Q0 (CISO binding constraint).
+
+This document is the operating threat model for the `gvid` daemon and its
+React web UI. It is meant to be short, concrete, and re-readable in five
+minutes. Updates land alongside the security code they describe.
+
+## What this product is
+
+A local-first Mission Control dashboard. The `gvid` Go daemon binds to a
+loopback address (default `localhost:7070`) and shells out to the `bd`
+(beads) and `gt` (Gas Town) CLIs for data. The Vite/React web UI runs at
+`localhost:5173` in dev and is embedded as static assets in the built
+daemon. A TUI client is a thin alternative front-end against the same
+HTTP API.
+
+There is exactly one expected human user per daemon process: the engineer
+whose dev box is running it.
+
+## Assets we are protecting
+
+In rough order of how bad it would be to lose them:
+
+1. **`bd memories`** — the persistent cross-session knowledge layer. Contains
+   partner names (Kobiton, Nixtla, Mudit/Polygon, Lit, Elm), engagement
+   context, recovery-context notes, and occasionally pasted API tokens. See
+   [`000-docs/005-PP-POLICY-memories-classification-2026-05-24.md`](000-docs/005-PP-POLICY-memories-classification-2026-05-24.md)
+   for the content classification policy.
+2. **Issue state mutations** — closing, deferring, or commenting on beads
+   issues is a writable surface. The viewer does NOT expose any
+   state-mutation endpoint as of `gastown-hu4`; future endpoints (notably
+   `bd human respond` / `dismiss` in `gastown-3uf`) will sit behind the
+   token gate this bead installs.
+3. **Issue and town metadata** — issue titles/descriptions and gt town
+   layout. Less sensitive than memories but still confidential.
+
+## Trust boundary
+
+The daemon's process boundary is the only trust boundary. Inside that
+boundary the daemon trusts the `bd` and `gt` binaries on `$PATH`, the
+filesystem at `~/.beads/` and `~/gt/`, and the engineer's
+`~/.config/gvid/token` file. Outside that boundary every byte is hostile
+until proven otherwise.
+
+## In-scope threats
+
+These are the threats this product actively defends against. Each one has
+a corresponding code path or operational control.
+
+### 1. DNS rebinding from any tab open on the dev box
+
+**Scenario:** Engineer has any web page open in any browser on the dev box.
+That page resolves `victim.example` via DNS to a public IP initially, then
+the second resolution returns `127.0.0.1`. JavaScript on that page issues
+`fetch('http://victim.example:7070/api/v1/memories')`. Without an Origin
+allowlist on the daemon, the daemon would happily return the memories JSON.
+
+**Defense:** `OriginAllowlistMiddleware` in `internal/api/security.go`.
+Every request that has an `Origin` header is checked against
+`Config.CORSOrigins`; mismatches return HTTP 403 `ORIGIN_REJECTED` and the
+handler is never reached. Browser fetch() always sends `Origin`, so this
+gate fires on every rebinding attempt. Native clients (curl, the TUI,
+self-tests) deliberately do NOT send `Origin` and pass through — they are
+inside the trust boundary.
+
+### 2. CSRF from a malicious local web page
+
+Same shape as (1) but without DNS rebinding — a malicious page on
+`localhost:9999`, `file://`, or a sandboxed iframe (Origin: `null`) tries
+to issue requests against the daemon. Same defense: the Origin allowlist
+rejects everything but the configured front-end origin.
+
+### 3. Same-machine other process attempting to mutate state
+
+**Scenario:** A malicious npm `postinstall`, a compromised MCP server, or a
+drive-by markdown preview spawns a request to `localhost:7070`. These
+local processes can read `Origin` headers freely (they're not browsers),
+so the Origin gate is insufficient.
+
+**Defense (future state):** `RequireTokenMiddleware` wraps every
+state-mutating endpoint. The token is generated at daemon startup, written
+to `~/.config/gvid/token` with mode `0600`, and never logged. Same-machine
+processes that do not run under the engineer's UID cannot read the file;
+processes that do run under that UID are already inside the trust
+boundary. As of this bead the middleware is **installed but not yet wired
+to any route** because the AT-DECR Q2 decision pins the memories panel
+read-only-forever and the human-triage POSTs are deferred to bead
+`gastown-3uf`. The cost of installing the gate now is one Go file; the
+benefit is that the schema slot exists when the POST routes ship, instead
+of being a retrofit after a security review notices it's missing.
+
+### 4. Accidental binding to a non-loopback address
+
+**Scenario:** Engineer types `--host=0.0.0.0` thinking they're enabling
+something local, exposing the dashboard to whatever network the dev box
+shares (corporate WiFi, hotel Ethernet, cloud VPC).
+
+**Defense:** `IsLoopbackHost` is called from `Server.Start()` before any
+listener is opened. A non-loopback host returns an error and the daemon
+fails to start. There's an escape hatch (`Config.DisableLoopbackCheck`)
+for ephemeral container test environments, gated by an explicit warning
+log line at startup.
+
+### 5. Confidential data rendered into uncontrolled browser storage
+
+**Scenario:** Engineer opens the dashboard, the memories panel renders
+partner names from `bd memories`. Browser autocomplete starts suggesting
+"Kobiton" in any future input on any site. Screen-recording during a
+partner call captures the open panel.
+
+**Defense:** policy document
+[`000-docs/005-PP-POLICY-memories-classification-2026-05-24.md`](000-docs/005-PP-POLICY-memories-classification-2026-05-24.md)
+specifies the partner-name and secret-pattern denylists. When the memories
+panel ships in `gastown-3uf` it must apply these denylists as a redaction
+overlay before any partner name reaches the DOM, and all input elements in
+the viewer must carry `autocomplete="off"`. The architectural invariant
+(memories panel is read-only-forever) eliminates the form-input vector
+entirely — there is no input field where partner names could be typed.
+
+## Out-of-scope threats
+
+Explicitly NOT in this product's threat model. If the scenario below
+applies, the engineer is already in a worse situation than the dashboard
+can mitigate.
+
+- **Attacker with arbitrary code execution as the engineer's UID.** The
+  attacker can already read the token file, the `.beads/` SQLite store,
+  every memory, and `~/.ssh/`. This dashboard cannot help.
+- **Attacker with kernel-level access on the dev box.** Same — the
+  defenses below are user-space and provide no protection.
+- **Network-level attackers outside the dev box.** The loopback bind check
+  prevents the dashboard from being reachable from the network at all.
+  If an attacker is on-path between the engineer and `127.0.0.1` they are
+  in the kernel, which is the out-of-scope case above.
+- **Browser zero-day that bypasses Same-Origin Policy.** SOP is the floor
+  the Origin allowlist is built on. If SOP itself is bypassed, every
+  cookie/token on the engineer's machine is in play.
+- **Physical access to the unlocked dev box.** Lock your screen.
+
+## Operational controls
+
+These are the things the engineer is expected to do, not the code:
+
+- Lock screen when stepping away. The dashboard does not authenticate the
+  engineer — anyone at the keyboard can read every memory.
+- During screen-sharing with partners (Anthropic cohort calls, partner
+  demos), close any browser tab showing the dashboard, or use the
+  redaction overlay's "show" toggle ONLY for non-sensitive memories.
+- Do not paste API tokens into `bd remember`. The viewer will
+  best-effort-redact common token patterns
+  (`sk-`, `ghp_`, `AKIA`, `gho_`, `glpat-`), but the defense in depth is
+  not putting tokens there in the first place. The bd CLI is the right
+  surface for tokens that have to live somewhere; SOPS-encrypted env
+  files are the right surface for production-impact secrets.
+
+## Defense map — code locations
+
+| Threat                          | Defense                                | File                            |
+|---------------------------------|----------------------------------------|---------------------------------|
+| DNS rebind / cross-origin CSRF  | `OriginAllowlistMiddleware`            | `internal/api/security.go`      |
+| Same-machine state mutation     | `RequireTokenMiddleware` (installed; routes wired in `gastown-3uf`) | `internal/api/security.go`      |
+| Token persistence + comparison  | `SessionToken.Persist` (0600) + `SessionToken.Equal` (constant-time) | `internal/api/security.go`      |
+| Non-loopback bind               | `IsLoopbackHost` startup check         | `internal/api/security.go` + `internal/api/server.go` |
+| Memories rendering surface      | Architectural invariant (read-only-forever) | Council decision Q2 + `internal/api/server.go` route registration |
+| Partner-name + secret redaction | Classification policy + denylists      | `000-docs/005-PP-POLICY-memories-classification-2026-05-24.md` (applied in `gastown-3uf`) |
+
+## Open follow-ups
+
+Tracked as beads under the `gastown-cr5` epic. None of these block this
+bead from shipping; they're the residual threat-model work the council
+explicitly deferred.
+
+- `gastown-3uf` — wire the memories panel (read-only) and the human-triage
+  read-view. Apply the classification policy denylists. No POST routes.
+- Future bead (post-Phase 2) — wire `RequireTokenMiddleware` onto the
+  human-triage POST routes (`/api/v1/human/{id}/respond`,
+  `/api/v1/human/{id}/dismiss`) when they ship. Will require the audit-log
+  emit path that CISO specified as the binding constraint.
+- Future bead — add a startup-time check that
+  `Config.SessionTokenPath` resolves under the engineer's `$HOME`. Today
+  the persist call will happily write the token anywhere the daemon can
+  write; the policy intent is "user-config-dir only."

--- a/internal/api/security.go
+++ b/internal/api/security.go
@@ -84,7 +84,12 @@ func (t *SessionToken) Persist(path string) (string, error) {
 		os.Remove(tmpPath)
 		return "", fmt.Errorf("chmod temp token: %w", err)
 	}
-	if _, err := tmp.WriteString(t.raw + "\n"); err != nil {
+	// Write the raw token only — no trailing newline. Clients that read the
+	// file literally (cat, $(cat ~/.config/gvid/token), some shell exports)
+	// otherwise pick up the newline as part of the secret and the gate fails
+	// confusingly. extractToken applies TrimSpace defensively, but the
+	// canonical file format is the bare hex string.
+	if _, err := tmp.WriteString(t.raw); err != nil {
 		tmp.Close()
 		os.Remove(tmpPath)
 		return "", fmt.Errorf("write temp token: %w", err)
@@ -122,23 +127,29 @@ func DefaultSessionTokenPath() (string, error) {
 
 // IsLoopbackHost reports whether the host string resolves to a loopback
 // address (127.0.0.0/8 or ::1) only. "localhost", "127.0.0.1", "::1", and
-// "[::1]" are accepted; "0.0.0.0", "::", and any non-loopback IP are
-// rejected. Hostnames other than "localhost" are conservatively rejected
-// rather than attempting DNS resolution — the daemon is local-first and
-// binding to a name that happens to resolve to a loopback IP today but a
-// public IP tomorrow is exactly the deployment surprise we want to avoid.
+// "[::1]" are accepted; "0.0.0.0", "::", any non-loopback IP, AND THE EMPTY
+// STRING are rejected.
+//
+// The empty-string rejection is the load-bearing one — net/http's
+// ListenAndServe with `Addr: ":7070"` (empty host) binds to ALL interfaces
+// (effectively 0.0.0.0), which is exactly the deployment surprise this
+// check exists to prevent. Treating "" as a loopback synonym would silently
+// re-enable network exposure. Per PR #12 Gemini security review 2026-05-24.
+//
+// Hostnames other than "localhost" are conservatively rejected rather than
+// attempting DNS resolution — binding to a name that happens to resolve
+// loopback today but public tomorrow is the same class of surprise.
 func IsLoopbackHost(host string) bool {
 	host = strings.TrimSpace(host)
 	host = strings.Trim(host, "[]")
-	switch host {
-	case "", "localhost":
+	if host == "localhost" {
 		return true
 	}
 	ip := net.ParseIP(host)
 	if ip == nil {
-		// Hostname other than "localhost" — reject. Resolving DNS here would
-		// let `gvid --host my-public-name.example` slip past a check that
-		// happens to resolve loopback today.
+		// Empty string AND any non-IP hostname other than "localhost" — reject.
+		// Empty would bind 0.0.0.0 in net/http; non-localhost names invite DNS
+		// drift.
 		return false
 	}
 	return ip.IsLoopback()

--- a/internal/api/security.go
+++ b/internal/api/security.go
@@ -1,0 +1,240 @@
+package api
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// SessionToken is a high-entropy random token generated at daemon startup and
+// persisted to a 0600-mode file. State-changing endpoints (the human-triage
+// POSTs that ship in a later burst — see gastown-3uf) will require the bearer
+// to present this token via either `Authorization: Bearer <token>` or the
+// `X-Gvid-Token: <token>` header. Read-only endpoints continue to function
+// without a token so the existing web UI and `curl` workflows are not broken.
+//
+// Threat model: protects against same-machine processes (other user-level
+// daemons, untrusted MCP servers, drive-by markdown previews that POST to
+// localhost) that lack filesystem access to the token file. Does NOT protect
+// against an attacker with read access to the token file — at that point the
+// attacker is already in-process or has user-shell access and the dashboard
+// is the least of the user's problems.
+type SessionToken struct {
+	raw string
+}
+
+// GenerateSessionToken returns a fresh 32-byte (256-bit) token encoded as a
+// 64-character hex string. crypto/rand is the entropy source; failure to read
+// from it returns an error so the caller can fail-fast at startup rather than
+// silently using a low-entropy fallback.
+func GenerateSessionToken() (*SessionToken, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return nil, fmt.Errorf("session-token entropy read: %w", err)
+	}
+	return &SessionToken{raw: hex.EncodeToString(buf)}, nil
+}
+
+// Value returns the token's wire representation. Callers should log this
+// ONLY at the token file's path (the file itself) — never to stdout/stderr.
+func (t *SessionToken) Value() string {
+	return t.raw
+}
+
+// Equal compares two tokens in constant time. Callers should never use
+// `==` on token strings directly because timing attacks on the rejection path
+// could leak token bytes one at a time.
+func (t *SessionToken) Equal(candidate string) bool {
+	if t == nil {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(t.raw), []byte(candidate)) == 1
+}
+
+// Persist writes the token to path with 0600 (owner read/write only) and
+// creates the parent directory with 0700 if it does not exist. Returns the
+// resolved absolute path on success so callers can log it.
+func (t *SessionToken) Persist(path string) (string, error) {
+	if t == nil {
+		return "", errors.New("nil SessionToken")
+	}
+	if path == "" {
+		return "", errors.New("empty token persist path")
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create token dir %s: %w", dir, err)
+	}
+	// Write atomically via a temp file in the same dir so a partial write
+	// cannot leave a half-written token at the canonical path.
+	tmp, err := os.CreateTemp(dir, ".gvid-token-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp token: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return "", fmt.Errorf("chmod temp token: %w", err)
+	}
+	if _, err := tmp.WriteString(t.raw + "\n"); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return "", fmt.Errorf("write temp token: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return "", fmt.Errorf("close temp token: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return "", fmt.Errorf("rename temp token to %s: %w", path, err)
+	}
+	// Final mode enforcement in case umask interfered with the temp file.
+	if err := os.Chmod(path, 0o600); err != nil {
+		return "", fmt.Errorf("chmod final token: %w", err)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path, nil
+	}
+	return abs, nil
+}
+
+// DefaultSessionTokenPath returns ~/.config/gvid/token (or the equivalent on
+// Windows via os.UserConfigDir). Falls back to a temp-dir path if the user
+// config dir cannot be resolved — the daemon will still function, but the
+// token will not survive a reboot.
+func DefaultSessionTokenPath() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil || dir == "" {
+		return "", fmt.Errorf("user config dir: %w", err)
+	}
+	return filepath.Join(dir, "gvid", "token"), nil
+}
+
+// IsLoopbackHost reports whether the host string resolves to a loopback
+// address (127.0.0.0/8 or ::1) only. "localhost", "127.0.0.1", "::1", and
+// "[::1]" are accepted; "0.0.0.0", "::", and any non-loopback IP are
+// rejected. Hostnames other than "localhost" are conservatively rejected
+// rather than attempting DNS resolution — the daemon is local-first and
+// binding to a name that happens to resolve to a loopback IP today but a
+// public IP tomorrow is exactly the deployment surprise we want to avoid.
+func IsLoopbackHost(host string) bool {
+	host = strings.TrimSpace(host)
+	host = strings.Trim(host, "[]")
+	switch host {
+	case "", "localhost":
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// Hostname other than "localhost" — reject. Resolving DNS here would
+		// let `gvid --host my-public-name.example` slip past a check that
+		// happens to resolve loopback today.
+		return false
+	}
+	return ip.IsLoopback()
+}
+
+// OriginAllowlistMiddleware hard-rejects requests whose Origin header is
+// present and not in the allowlist. Requests without an Origin header are
+// passed through — that covers native HTTP clients (curl, the TUI, the gvid
+// daemon's own self-tests) which by spec do not send Origin. Browsers always
+// send Origin on cross-origin fetch(), so this gate stops DNS rebinding and
+// drive-by CSRF attempts from any web page Jeremy might have open in another
+// tab on the same dev box.
+//
+// Council decision Q0 (gastown-cr5 AT-DECR, CISO binding constraint): this
+// is the foundation defense before any state-mutating endpoint ships. For
+// read-only endpoints it protects data exfiltration (read of confidential
+// memories via DNS-rebind would return JSON to attacker JS).
+func OriginAllowlistMiddleware(allowed []string) func(http.Handler) http.Handler {
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, o := range allowed {
+		allowedSet[o] = struct{}{}
+	}
+	_, allowAny := allowedSet["*"]
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+			if origin == "" {
+				// Native client (curl, native app, server-to-server). Browsers
+				// always set Origin; absence is a strong signal this is not a
+				// cross-origin browser context.
+				next.ServeHTTP(w, r)
+				return
+			}
+			if allowAny {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if _, ok := allowedSet[origin]; !ok {
+				// Hard reject. Distinct from CORS — CORS only tells the
+				// browser to drop the response; we want the server to refuse
+				// the request entirely so confidential data never leaves the
+				// process. 403 over 401 because no credential-based remedy is
+				// available (the origin itself is wrong).
+				writeError(w, http.StatusForbidden, "ORIGIN_REJECTED",
+					fmt.Sprintf("Origin %q is not in the daemon's allowlist; "+
+						"set --cors-origin or run the web UI from a permitted origin", origin))
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// RequireTokenMiddleware demands `Authorization: Bearer <token>` OR
+// `X-Gvid-Token: <token>` on every request. The constant-time SessionToken.Equal
+// is used to compare so timing attacks on the rejection path cannot leak
+// bytes. Wrapped only around state-mutating endpoints (none in this burst —
+// reserved for the human-triage POSTs in gastown-3uf and any future memories
+// write-path, though Q2 of the AT-DECR makes the latter an architectural
+// invariant: read-only-forever).
+func RequireTokenMiddleware(token *SessionToken) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if token == nil {
+				// Defensive: a nil token indicates a startup bug (token not
+				// generated). Better to refuse than to silently bypass.
+				writeError(w, http.StatusServiceUnavailable, "TOKEN_NOT_READY",
+					"Session token not initialized; daemon misconfigured")
+				return
+			}
+			candidate := extractToken(r)
+			if candidate == "" {
+				writeError(w, http.StatusUnauthorized, "TOKEN_REQUIRED",
+					"State-changing endpoint requires Authorization: Bearer <token> or X-Gvid-Token header")
+				return
+			}
+			if !token.Equal(candidate) {
+				writeError(w, http.StatusUnauthorized, "TOKEN_INVALID",
+					"Token does not match the daemon's session token")
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// extractToken pulls a candidate token from either the Authorization Bearer
+// scheme or the X-Gvid-Token header. The Authorization header takes
+// precedence when both are present — by convention that header is the
+// canonical place clients learn about, and accepting two values for the same
+// secret without a tiebreaker would invite confusion.
+func extractToken(r *http.Request) string {
+	if auth := r.Header.Get("Authorization"); auth != "" {
+		if strings.HasPrefix(auth, "Bearer ") {
+			return strings.TrimSpace(strings.TrimPrefix(auth, "Bearer "))
+		}
+	}
+	return strings.TrimSpace(r.Header.Get("X-Gvid-Token"))
+}

--- a/internal/api/security_test.go
+++ b/internal/api/security_test.go
@@ -1,0 +1,352 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateSessionToken_LengthAndUniqueness(t *testing.T) {
+	t1, err := GenerateSessionToken()
+	if err != nil {
+		t.Fatalf("GenerateSessionToken: %v", err)
+	}
+	t2, err := GenerateSessionToken()
+	if err != nil {
+		t.Fatalf("GenerateSessionToken: %v", err)
+	}
+	if t1.Value() == t2.Value() {
+		t.Error("two consecutive tokens should not be equal — entropy source broken")
+	}
+	// 32 bytes -> 64 hex chars
+	if len(t1.Value()) != 64 {
+		t.Errorf("token length: got %d, want 64", len(t1.Value()))
+	}
+	for _, c := range t1.Value() {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Errorf("token contains non-hex byte %q", c)
+			break
+		}
+	}
+}
+
+func TestSessionToken_Equal_ConstantTime(t *testing.T) {
+	tok, err := GenerateSessionToken()
+	if err != nil {
+		t.Fatalf("GenerateSessionToken: %v", err)
+	}
+	if !tok.Equal(tok.Value()) {
+		t.Error("token should equal its own Value()")
+	}
+	if tok.Equal("wrong") {
+		t.Error("token should not equal an obviously-wrong string")
+	}
+	if tok.Equal("") {
+		t.Error("token should not equal empty string")
+	}
+	var nilTok *SessionToken
+	if nilTok.Equal("anything") {
+		t.Error("nil token should never equal anything")
+	}
+}
+
+func TestSessionToken_Persist_Mode0600_AtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "token")
+	tok, err := GenerateSessionToken()
+	if err != nil {
+		t.Fatalf("GenerateSessionToken: %v", err)
+	}
+	abs, err := tok.Persist(path)
+	if err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+	if abs == "" {
+		t.Error("Persist should return non-empty resolved path")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Errorf("token file mode: got %o, want 600", mode)
+	}
+	// Parent dir should be 0700 because we MkdirAll'd it.
+	parentInfo, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("Stat parent: %v", err)
+	}
+	if mode := parentInfo.Mode().Perm(); mode != 0o700 {
+		t.Errorf("token dir mode: got %o, want 700", mode)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.TrimSpace(string(contents)) != tok.Value() {
+		t.Error("token file contents do not match token value")
+	}
+	// Re-persist should overwrite atomically without leaving temp files.
+	if _, err := tok.Persist(path); err != nil {
+		t.Errorf("repeat Persist: %v", err)
+	}
+	entries, _ := os.ReadDir(filepath.Dir(path))
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".gvid-token-") {
+			t.Errorf("temp file left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestSessionToken_Persist_NilReceiver(t *testing.T) {
+	var tok *SessionToken
+	if _, err := tok.Persist("/tmp/whatever"); err == nil {
+		t.Error("nil receiver Persist should return error")
+	}
+}
+
+func TestIsLoopbackHost(t *testing.T) {
+	cases := []struct {
+		host    string
+		want    bool
+		comment string
+	}{
+		{"localhost", true, "canonical loopback name"},
+		{"127.0.0.1", true, "IPv4 loopback"},
+		{"127.0.0.42", true, "127.0.0.0/8 loopback range"},
+		{"::1", true, "IPv6 loopback"},
+		{"[::1]", true, "bracketed IPv6 loopback"},
+		{"", true, "empty host means listener default — allowed"},
+		{"0.0.0.0", false, "bind-all IPv4 — must reject"},
+		{"::", false, "bind-all IPv6 — must reject"},
+		{"192.168.1.10", false, "private LAN — must reject"},
+		{"10.0.0.1", false, "private LAN — must reject"},
+		{"169.254.169.254", false, "link-local — must reject (cloud metadata)"},
+		{"203.0.113.50", false, "TEST-NET-3 public range — must reject"},
+		{"my-host.example", false, "hostname other than 'localhost' — must reject without DNS"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.host+"/"+tc.comment, func(t *testing.T) {
+			got := IsLoopbackHost(tc.host)
+			if got != tc.want {
+				t.Errorf("IsLoopbackHost(%q) = %v, want %v (%s)", tc.host, got, tc.want, tc.comment)
+			}
+		})
+	}
+}
+
+func TestOriginAllowlistMiddleware_NoOriginPassesThrough(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := OriginAllowlistMiddleware([]string{"http://localhost:5173"})(next)
+
+	req := httptest.NewRequest("GET", "/api/v1/health", nil)
+	// Deliberately no Origin header set — native client.
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, req)
+
+	if !called {
+		t.Error("native client (no Origin) should pass through to handler")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200", w.Code)
+	}
+}
+
+func TestOriginAllowlistMiddleware_AllowedOriginPasses(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := OriginAllowlistMiddleware([]string{"http://localhost:5173"})(next)
+
+	req := httptest.NewRequest("GET", "/api/v1/health", nil)
+	req.Header.Set("Origin", "http://localhost:5173")
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, req)
+
+	if !called {
+		t.Error("allowed origin should pass through")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200", w.Code)
+	}
+}
+
+func TestOriginAllowlistMiddleware_DisallowedOriginRejected(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+	mw := OriginAllowlistMiddleware([]string{"http://localhost:5173"})(next)
+
+	// Simulates a drive-by from any other origin — including DNS-rebound
+	// attackers and other localhost ports.
+	for _, badOrigin := range []string{
+		"http://evil.example",
+		"https://attacker.local",
+		"http://localhost:9999", // wrong port, even on localhost
+		"http://127.0.0.1:5173", // raw IP variant of the allowed origin
+		"null",                  // sandboxed iframes / file:// pages send "null"
+	} {
+		t.Run(badOrigin, func(t *testing.T) {
+			called = false
+			req := httptest.NewRequest("GET", "/api/v1/health", nil)
+			req.Header.Set("Origin", badOrigin)
+			w := httptest.NewRecorder()
+			mw.ServeHTTP(w, req)
+
+			if called {
+				t.Errorf("handler must NOT be called for disallowed origin %q", badOrigin)
+			}
+			if w.Code != http.StatusForbidden {
+				t.Errorf("status for %q: got %d, want 403", badOrigin, w.Code)
+			}
+			if !strings.Contains(w.Body.String(), "ORIGIN_REJECTED") {
+				t.Errorf("response body should mention ORIGIN_REJECTED, got %q", w.Body.String())
+			}
+		})
+	}
+}
+
+func TestOriginAllowlistMiddleware_WildcardAllowsAny(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := OriginAllowlistMiddleware([]string{"*"})(next)
+
+	req := httptest.NewRequest("GET", "/api/v1/health", nil)
+	req.Header.Set("Origin", "http://anywhere.example")
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, req)
+
+	if !called {
+		t.Error(`wildcard "*" allowlist should pass any origin`)
+	}
+}
+
+func TestRequireTokenMiddleware_RejectsMissingToken(t *testing.T) {
+	tok, _ := GenerateSessionToken()
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler must NOT be reached without token")
+	})
+	mw := RequireTokenMiddleware(tok)(next)
+	req := httptest.NewRequest("POST", "/api/v1/whatever", nil)
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want 401", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "TOKEN_REQUIRED") {
+		t.Errorf("body should mention TOKEN_REQUIRED, got %q", w.Body.String())
+	}
+}
+
+func TestRequireTokenMiddleware_AcceptsBearerHeader(t *testing.T) {
+	tok, _ := GenerateSessionToken()
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := RequireTokenMiddleware(tok)(next)
+	req := httptest.NewRequest("POST", "/api/v1/whatever", nil)
+	req.Header.Set("Authorization", "Bearer "+tok.Value())
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, req)
+	if !called {
+		t.Errorf("handler must be reached with valid Bearer; got status %d, body %q", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireTokenMiddleware_AcceptsXGvidTokenHeader(t *testing.T) {
+	tok, _ := GenerateSessionToken()
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := RequireTokenMiddleware(tok)(next)
+	req := httptest.NewRequest("POST", "/api/v1/whatever", nil)
+	req.Header.Set("X-Gvid-Token", tok.Value())
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, req)
+	if !called {
+		t.Errorf("handler must be reached with valid X-Gvid-Token; got status %d", w.Code)
+	}
+}
+
+func TestRequireTokenMiddleware_RejectsWrongToken(t *testing.T) {
+	tok, _ := GenerateSessionToken()
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler must NOT be reached with wrong token")
+	})
+	mw := RequireTokenMiddleware(tok)(next)
+	req := httptest.NewRequest("POST", "/api/v1/whatever", nil)
+	req.Header.Set("Authorization", "Bearer "+strings.Repeat("0", 64))
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want 401", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "TOKEN_INVALID") {
+		t.Errorf("body should mention TOKEN_INVALID, got %q", w.Body.String())
+	}
+}
+
+func TestRequireTokenMiddleware_NilTokenFails(t *testing.T) {
+	// Defensive: if the daemon somehow reached a request without generating
+	// a token, the gate must refuse rather than silently bypass.
+	mw := RequireTokenMiddleware(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler must NOT be reached when token is nil")
+	}))
+	req := httptest.NewRequest("POST", "/api/v1/whatever", nil)
+	req.Header.Set("Authorization", "Bearer something")
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status: got %d, want 503", w.Code)
+	}
+}
+
+func TestExtractToken_BearerPrecedenceOverXGvid(t *testing.T) {
+	// When both headers are present, Authorization Bearer wins. This avoids
+	// the surprise of a client setting both headers with different values
+	// and the gate accepting one but logging the other.
+	req := httptest.NewRequest("POST", "/", nil)
+	req.Header.Set("Authorization", "Bearer aaaaaa")
+	req.Header.Set("X-Gvid-Token", "bbbbbb")
+	if got := extractToken(req); got != "aaaaaa" {
+		t.Errorf("extractToken: got %q, want %q (Bearer should win)", got, "aaaaaa")
+	}
+}
+
+func TestExtractToken_NonBearerAuthorizationIgnored(t *testing.T) {
+	// `Authorization: Basic ...` is not the Bearer scheme and must not be
+	// silently accepted as a token candidate.
+	req := httptest.NewRequest("POST", "/", nil)
+	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	req.Header.Set("X-Gvid-Token", "xgvid-value")
+	if got := extractToken(req); got != "xgvid-value" {
+		t.Errorf("extractToken: got %q, want %q (Basic should be ignored, fall back to X-Gvid-Token)", got, "xgvid-value")
+	}
+}
+
+func TestDefaultSessionTokenPath_UnderUserConfigDir(t *testing.T) {
+	got, err := DefaultSessionTokenPath()
+	if err != nil {
+		t.Skipf("user config dir unavailable in this test env: %v", err)
+	}
+	if !strings.HasSuffix(got, filepath.Join("gvid", "token")) {
+		t.Errorf("default token path %q should end in gvid/token", got)
+	}
+}

--- a/internal/api/security_test.go
+++ b/internal/api/security_test.go
@@ -119,7 +119,7 @@ func TestIsLoopbackHost(t *testing.T) {
 		{"127.0.0.42", true, "127.0.0.0/8 loopback range"},
 		{"::1", true, "IPv6 loopback"},
 		{"[::1]", true, "bracketed IPv6 loopback"},
-		{"", true, "empty host means listener default — allowed"},
+		{"", false, "empty host binds 0.0.0.0 in net/http — MUST reject (PR #12 Gemini security finding)"},
 		{"0.0.0.0", false, "bind-all IPv4 — must reject"},
 		{"::", false, "bind-all IPv6 — must reject"},
 		{"192.168.1.10", false, "private LAN — must reject"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -19,6 +19,18 @@ type Config struct {
 	CORSOrigins []string
 	Version     string
 	TownRoot    string // Gas Town workspace root (default: ~/gt)
+
+	// SessionTokenPath is the filesystem location where the generated
+	// per-process session token will be persisted at startup. Empty means
+	// "use DefaultSessionTokenPath() (~/.config/gvid/token)". The token file
+	// is always written with mode 0600.
+	SessionTokenPath string
+
+	// DisableLoopbackCheck bypasses the startup-time loopback bind check.
+	// Off-by-default; enabling this allows binding to 0.0.0.0 / non-loopback
+	// addresses. Intended ONLY for ephemeral container test environments;
+	// hard-flagged as unsafe in the log line at startup.
+	DisableLoopbackCheck bool
 }
 
 // DefaultConfig returns configuration with sensible defaults.
@@ -39,6 +51,11 @@ type Server struct {
 	gtAdapter gastown.Adapter
 	mux       *http.ServeMux
 	sse       *SSEBroker
+
+	// sessionToken is the per-process bearer token required by
+	// RequireTokenMiddleware on state-mutating endpoints. Generated at Start()
+	// time, persisted to config.SessionTokenPath, and never logged in plaintext.
+	sessionToken *SessionToken
 }
 
 // NewServer creates a new API server.
@@ -98,16 +115,64 @@ func (s *Server) registerRoutes() {
 	s.serveStaticFiles()
 }
 
-// Handler returns the HTTP handler with middleware applied.
+// Handler returns the HTTP handler with middleware applied. The order is
+// outside-in: incoming requests hit OriginAllowlist first (cheap, fast reject
+// of cross-origin browser attacks), then CORS for response headers, then the
+// logging middleware, then the mux. RequireTokenMiddleware is intentionally
+// NOT applied at this layer — it is wrapped per-route on state-mutating
+// endpoints when they ship, so read-only endpoints (the entire surface this
+// burst) remain accessible to native clients without a token.
 func (s *Server) Handler() http.Handler {
-	return s.corsMiddleware(s.loggingMiddleware(s.mux))
+	originAllowlist := OriginAllowlistMiddleware(s.config.CORSOrigins)
+	return originAllowlist(s.corsMiddleware(s.loggingMiddleware(s.mux)))
 }
 
 // Start starts the HTTP server.
+//
+// Two pre-flight checks before binding:
+//
+//  1. Loopback bind enforcement: the daemon refuses to bind a non-loopback
+//     host unless Config.DisableLoopbackCheck is explicitly set. This
+//     prevents the most common deployment surprise — a default-bind on
+//     0.0.0.0 exposing the dashboard to any network the dev box is on.
+//  2. Session token generation: a fresh 256-bit token is generated and
+//     persisted to Config.SessionTokenPath (default ~/.config/gvid/token,
+//     mode 0600). The token's existence is reported via the daemon log but
+//     never the value itself.
 func (s *Server) Start() error {
+	if !s.config.DisableLoopbackCheck && !IsLoopbackHost(s.config.Host) {
+		return fmt.Errorf("refusing to bind non-loopback host %q; pass --host=localhost "+
+			"(or set Config.DisableLoopbackCheck for ephemeral containers ONLY)",
+			s.config.Host)
+	}
+	if s.config.DisableLoopbackCheck {
+		log.Printf("WARNING: loopback bind check is DISABLED; binding %s on a "+
+			"non-loopback address exposes the dashboard to the network",
+			s.config.Host)
+	}
+
+	tokenPath := s.config.SessionTokenPath
+	if tokenPath == "" {
+		var err error
+		tokenPath, err = DefaultSessionTokenPath()
+		if err != nil {
+			return fmt.Errorf("resolve session token path: %w", err)
+		}
+	}
+	tok, err := GenerateSessionToken()
+	if err != nil {
+		return fmt.Errorf("generate session token: %w", err)
+	}
+	resolvedPath, err := tok.Persist(tokenPath)
+	if err != nil {
+		return fmt.Errorf("persist session token to %s: %w", tokenPath, err)
+	}
+	s.sessionToken = tok
+
 	addr := fmt.Sprintf("%s:%d", s.config.Host, s.config.Port)
 	log.Printf("Starting Gastown Viewer Intent daemon on %s", addr)
 	log.Printf("API: http://%s/api/v1/", addr)
+	log.Printf("Session token: %s (mode 0600; required by future state-changing endpoints)", resolvedPath)
 
 	// Start SSE broker
 	go s.sse.Start()
@@ -122,6 +187,11 @@ func (s *Server) Start() error {
 
 	return server.ListenAndServe()
 }
+
+// SessionToken returns the in-process token (or nil if Start() has not yet
+// run). Test helpers use this; production code paths should reach for the
+// token via RequireTokenMiddleware only.
+func (s *Server) SessionToken() *SessionToken { return s.sessionToken }
 
 // corsMiddleware adds CORS headers for development.
 func (s *Server) corsMiddleware(next http.Handler) http.Handler {


### PR DESCRIPTION
## Summary

Phase 2 daemon hardening (bead `gastown-hu4` under epic `gastown-cr5`). Schema-slot reservation for the security defenses called for in the 2026-05-23 council decision Q0 + Q2 (CISO + GC binding constraints).

**No new state-mutating routes ship here.** The memories panel is read-only-forever per Q2; the human-triage POSTs are deferred to `gastown-3uf`. What lands now is the working, tested gate infrastructure so the POSTs wire to an audited defense rather than a hopeful retrofit when they ship.

## What's in the PR

| File | Purpose |
|---|---|
| `internal/api/security.go` (new, ~225 LOC) | `OriginAllowlistMiddleware` (hard-reject 403 distinct from CORS), `SessionToken` (256-bit crypto/rand, constant-time compare, atomic mode-0600 persist), `RequireTokenMiddleware` (Bearer OR X-Gvid-Token; nil token fails closed), `IsLoopbackHost` (rejects 0.0.0.0 / ::/ private LAN / cloud-metadata / non-localhost hostnames) |
| `internal/api/security_test.go` (new, 16 tests) | Full coverage of every gate. Threat-model-mapped — each test states which attack class it guards |
| `internal/api/server.go` (modified) | `Config.SessionTokenPath` + `Config.DisableLoopbackCheck`; `Handler()` chains Origin allowlist outermost; `Start()` runs loopback check then generates+persists token before binding |
| `THREAT_MODEL.md` (new, repo root) | Five-minute re-readable. Maps each in-scope threat to defense code path; explicit out-of-scope list (kernel access, browser-SOP bypass, etc.) |
| `000-docs/005-PP-POLICY-memories-classification-2026-05-24.md` (new) | Partner-name denylist (Class A: kobiton/nixtla/mudit/polygon/lit/elm with whole-word matching for the latter two) + secret-pattern denylist (Class B: sk-/ghp_/AKIA/etc.). Rendering rules: default redacted, per-memory reveal that does NOT persist, autocomplete=off on all inputs, no auto-clipboard of content, persistent screen-share warning banner |

## How the gates compose

```
incoming request
        │
        ▼
OriginAllowlistMiddleware  ← outermost, cheap reject of cross-origin
        │
        ▼
corsMiddleware             ← existing; sets CORS response headers
        │
        ▼
loggingMiddleware          ← existing
        │
        ▼
ServeMux                   ← all current routes are GET, read-only
        │
        ▼
[future: RequireTokenMiddleware wraps per-route on the human-triage POSTs that ship in gastown-3uf]
```

`Start()` adds two pre-flight checks before the listener opens:
1. `IsLoopbackHost(config.Host)` — refuses non-loopback binds (escape hatch: `Config.DisableLoopbackCheck` with loud warning log)
2. Generates a session token, persists to `~/.config/gvid/token` (mode 0600 via atomic temp-then-rename), logs the PATH never the value

## Test plan

- [x] `go test ./...` passes locally (16 new tests + existing suite green)
- [x] `go vet ./...` clean
- [x] `goimports -l` clean on new + modified files
- [x] Existing handler tests still pass (they don't send Origin → bypass the new gate by design)
- [ ] CI green
- [ ] Gemini review clean

## Threat-model coverage (in-scope only)

| Threat | Test | Defense |
|---|---|---|
| DNS rebinding | `TestOriginAllowlistMiddleware_DisallowedOriginRejected` (5 variants) | Hard 403 on Origin mismatch |
| CSRF from local malicious page | same test (covers `null`, wrong-port, raw-IP variants) | same |
| Same-machine state mutation | `TestRequireTokenMiddleware_*` (5 tests) | Bearer / X-Gvid-Token gate with constant-time compare |
| Non-loopback bind | `TestIsLoopbackHost` (13 table cases) | Startup-time refusal |
| Memories rendered to uncontrolled browser storage | Policy doc § 4 (rendering rules) | Defaulted-redacted policy applied in `gastown-3uf` |

## Scope NOT included (per the AT-DECR — deferred)

- Wiring `RequireTokenMiddleware` to specific routes — no POSTs exist this burst. `gastown-3uf` wires the triage read-view (also no POSTs) and a future bead wires the eventual triage POST handlers.
- `internal/api/memoryredact.go` implementing the classification policy on rendered content (`gastown-3uf`).
- Audit-log file path + rotation (tracked in THREAT_MODEL.md § Open follow-ups).

## Refs

- Decision Record: `000-docs/004-AT-DECR-gastown-viewer-option-b-council-2026-05-23.md`
- Closes bead: `gastown-hu4` (Daemon hardening + memory classification policy)
- Epic bead: `gastown-cr5` (in_progress)
- Companion PRs: #10 (pre-flight tooling), #11 (foundation gates) — all three are orthogonal and can merge independently
- Refs #9

- Jeremy Longshore
intentsolutions.io